### PR TITLE
fixing normalized peak2peak bug with float type cast

### DIFF
--- a/Source/GridViewerCanvas.cpp
+++ b/Source/GridViewerCanvas.cpp
@@ -173,7 +173,7 @@ void GridViewerCanvas::refresh()
 
     for (int i = 0; i < maxChan; i++)
     {
-        electrodes[i]->setColour(ColourScheme::getColourForNormalizedValue(peakToPeakValues[i] / 200));
+        electrodes[i]->setColour(ColourScheme::getColourForNormalizedValue((float)(peakToPeakValues[i] / 200)));
     }
 
     repaint();


### PR DESCRIPTION
The grid was not updating visually because the normalized peak2peak values were being truncated to 0. This type cast fixes this issue and results in the graph refreshing as expected.